### PR TITLE
rkt: Support multiple containers in nomad

### DIFF
--- a/client/driver/rkt_test.go
+++ b/client/driver/rkt_test.go
@@ -85,7 +85,7 @@ func TestRktDriver_Fingerprint(t *testing.T) {
 	}
 }
 
-func TestRktDriver_Start_DNS(t *testing.T) {
+func TestRktDriver_Start_DNS_With_Image(t *testing.T) {
 	if !testutil.IsTravis() {
 		t.Parallel()
 	}
@@ -139,7 +139,155 @@ func TestRktDriver_Start_DNS(t *testing.T) {
 	handle2.Kill()
 }
 
-func TestRktDriver_Start_Wait(t *testing.T) {
+func TestRktDriver_Start_DNS_With_SingleApp_PodManifest(t *testing.T) {
+	if !testutil.IsTravis() {
+		t.Parallel()
+	}
+	if os.Getenv("NOMAD_TEST_RKT") == "" {
+		t.Skip("skipping rkt tests")
+	}
+
+	ctestutils.RktCompatible(t)
+	task := &structs.Task{
+		Name:   "etcd",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"pod_manifest": `{
+				"acVersion": "1.27.0",
+				"acKind": "PodManifest",
+				"apps": [
+					{
+						"name": "coreos",
+						"image": {
+							"name": "coreos.com/etcd",
+							"labels": [
+								{
+									"name":  "version",
+									"value": "v2.0.4"
+								}
+							]
+						},
+						"app": {
+							"exec": ["/etcd"],
+							"user": "0",
+							"group": "0"
+						}
+					}
+				]
+			}`,
+			"dns_servers":        []string{"8.8.8.8", "8.8.4.4"},
+			"dns_search_domains": []string{"example.com", "example.org", "example.net"},
+		},
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+		Resources: &structs.Resources{
+			MemoryMB: 128,
+			CPU:      100,
+		},
+	}
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
+	resp, err := d.Start(ctx.ExecCtx, task)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer resp.Handle.Kill()
+
+	// Attempt to open a handle to a nomad task
+	handle2, err := d.Open(ctx.ExecCtx, resp.Handle.ID())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if handle2 == nil {
+		t.Fatalf("missing handle")
+	}
+	handle2.Kill()
+}
+
+func TestRktDriver_Start_DNS_With_MultipleApps_PodManifest(t *testing.T) {
+	if !testutil.IsTravis() {
+		t.Parallel()
+	}
+	if os.Getenv("NOMAD_TEST_RKT") == "" {
+		t.Skip("skipping rkt tests")
+	}
+
+	ctestutils.RktCompatible(t)
+	task := &structs.Task{
+		Name:   "etcd_nginx",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"pod_manifest": `{
+				"acVersion": "1.27.0",
+				"acKind": "PodManifest",
+				"apps": [
+					{
+						"name": "coreos",
+						"image": {
+							"name": "coreos.com/etcd",
+							"labels": [
+								{
+									"name":  "version",
+									"value": "v2.0.4"
+								}
+							]
+						},
+						"app": {
+							"exec": ["/etcd"],
+							"user": "0",
+							"group": "0"
+						}
+					},
+					{
+						"name": "nginx",
+						"image": {
+							"name": "docker://registry-1.docker.io/library/nginx"
+						}
+					}
+				]
+			}`,
+			"dns_servers":        []string{"8.8.8.8", "8.8.4.4"},
+			"dns_search_domains": []string{"example.com", "example.org", "example.net"},
+		},
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+		Resources: &structs.Resources{
+			MemoryMB: 128,
+			CPU:      100,
+		},
+	}
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
+	resp, err := d.Start(ctx.ExecCtx, task)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer resp.Handle.Kill()
+
+	// Attempt to open a handle to a nomad task
+	handle2, err := d.Open(ctx.ExecCtx, resp.Handle.ID())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if handle2 == nil {
+		t.Fatalf("missing handle")
+	}
+	handle2.Kill()
+}
+
+func TestRktDriver_Start_Wait_With_Image(t *testing.T) {
 	if !testutil.IsTravis() {
 		t.Parallel()
 	}
@@ -167,6 +315,199 @@ func TestRktDriver_Start_Wait(t *testing.T) {
 		},
 	}
 
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
+	resp, err := d.Start(ctx.ExecCtx, task)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	handle := resp.Handle.(*rktHandle)
+	defer handle.Kill()
+
+	// Update should be a no-op
+	if err := handle.Update(task); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Signal should be an error
+	if err := resp.Handle.Signal(syscall.SIGTERM); err == nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	select {
+	case res := <-resp.Handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("err: %v", res)
+		}
+	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+		t.Fatalf("timeout")
+	}
+
+	// Make sure pod was removed #3561
+	var stderr bytes.Buffer
+	cmd := exec.Command(rktCmd, "status", handle.uuid)
+	cmd.Stdout = ioutil.Discard
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		t.Fatalf("expected error running 'rkt status %s' on removed container", handle.uuid)
+	}
+	if out := stderr.String(); !strings.Contains(out, "no matches found") {
+		t.Fatalf("expected 'no matches found' but received: %s", out)
+	}
+}
+
+func TestRktDriver_Start_Wait_With_SingleApp_PodManifest(t *testing.T) {
+	if !testutil.IsTravis() {
+		t.Parallel()
+	}
+	if os.Getenv("NOMAD_TEST_RKT") == "" {
+		t.Skip("skipping rkt tests")
+	}
+	ctestutils.RktCompatible(t)
+	task := &structs.Task{
+		Name:   "etcd",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"pod_manifest": `{
+				"acVersion": "1.27.0",
+				"acKind": "PodManifest",
+				"apps": [
+					{
+						"name": "coreos",
+						"image": {
+							"name": "coreos.com/etcd",
+							"labels": [
+								{
+									"name":  "version",
+									"value": "v2.0.4"
+								}
+							]
+						},
+						"app": {
+								"exec": ["/etcd","--version"],
+								"user": "0",
+								"group": "0"
+						}
+					}
+				]
+			}`,
+		},
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+		Resources: &structs.Resources{
+			MemoryMB: 128,
+			CPU:      100,
+		},
+	}
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
+	resp, err := d.Start(ctx.ExecCtx, task)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	handle := resp.Handle.(*rktHandle)
+	defer handle.Kill()
+
+	// Update should be a no-op
+	if err := handle.Update(task); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Signal should be an error
+	if err := resp.Handle.Signal(syscall.SIGTERM); err == nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	select {
+	case res := <-resp.Handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("err: %v", res)
+		}
+	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+		t.Fatalf("timeout")
+	}
+
+	// Make sure pod was removed #3561
+	var stderr bytes.Buffer
+	cmd := exec.Command(rktCmd, "status", handle.uuid)
+	cmd.Stdout = ioutil.Discard
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		t.Fatalf("expected error running 'rkt status %s' on removed container", handle.uuid)
+	}
+	if out := stderr.String(); !strings.Contains(out, "no matches found") {
+		t.Fatalf("expected 'no matches found' but received: %s", out)
+	}
+}
+
+func TestRktDriver_Start_Wait_With_MultipleApps_PodManifest(t *testing.T) {
+	if !testutil.IsTravis() {
+		t.Parallel()
+	}
+	if os.Getenv("NOMAD_TEST_RKT") == "" {
+		t.Skip("skipping rkt tests")
+	}
+	ctestutils.RktCompatible(t)
+	task := &structs.Task{
+		Name:   "etcd_alpine",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"pod_manifest": `{
+				"acVersion": "1.27.0",
+				"acKind": "PodManifest",
+				"apps": [
+					{
+						"name": "coreos",
+						"image": {
+							"name": "coreos.com/etcd",
+							"labels": [
+								{
+									"name":  "version",
+									"value": "v2.0.4"
+								}
+							]
+						},
+						"app": {
+								"exec": ["/etcd","--version"],
+								"user": "0",
+								"group": "0"
+						}
+					},
+					{
+						"name": "alpine",
+						"image": {
+							"name": "docker://alpine"
+						},
+						"app": {
+								"exec": ["/bin/sh"],
+								"user": "0",
+								"group": "0"
+						}
+					}
+				]
+			}`,
+		},
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+		Resources: &structs.Resources{
+			MemoryMB: 128,
+			CPU:      100,
+		},
+	}
 	ctx := testDriverContexts(t, task)
 	defer ctx.AllocDir.Destroy()
 	d := NewRktDriver(ctx.DriverCtx)
@@ -269,7 +610,7 @@ func TestRktDriver_Start_Wait_Skip_Trust(t *testing.T) {
 	}
 }
 
-func TestRktDriver_Start_Wait_AllocDir(t *testing.T) {
+func TestRktDriver_Start_Wait_AllocDir_With_Image(t *testing.T) {
 	if !testutil.IsTravis() {
 		t.Parallel()
 	}
@@ -332,7 +673,107 @@ func TestRktDriver_Start_Wait_AllocDir(t *testing.T) {
 	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
 		t.Fatalf("timeout")
 	}
+	// Check that data was written to the shared alloc directory.
+	act, err := ioutil.ReadFile(hostpath)
+	if err != nil {
+		t.Fatalf("Couldn't read expected output: %v", err)
+	}
 
+	if !reflect.DeepEqual(act, exp) {
+		t.Fatalf("Command output is %v; expected %v", act, exp)
+	}
+}
+
+func TestRktDriver_Start_Wait_AllocDir_With_Single_App_PodManifest(t *testing.T) {
+	if !testutil.IsTravis() {
+		t.Parallel()
+	}
+	if os.Getenv("NOMAD_TEST_RKT") == "" {
+		t.Skip("skipping rkt tests")
+	}
+
+	ctestutils.RktCompatible(t)
+
+	exp := []byte{'w', 'i', 'n'}
+	file := "output.txt"
+	tmpvol, err := ioutil.TempDir("", "nomadtest_rktdriver_volumes")
+	if err != nil {
+		t.Fatalf("error creating temporary dir: %v", err)
+	}
+	defer os.RemoveAll(tmpvol)
+	hostpath := filepath.Join(tmpvol, file)
+
+	task := &structs.Task{
+		Name:   "rkttest_alpine",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"pod_manifest": fmt.Sprintf(`{
+				"acVersion": "1.27.0",
+				"acKind": "PodManifest",
+				"apps": [
+					{
+						"name": "alpine",
+						"image": {
+							"name": "docker://alpine"
+						},
+						"app": {
+							"exec": [
+                                "/bin/sh",
+								"-c",
+								"echo -n %s > foo/%s"
+                            ],
+							"user": "0",
+							"group": "0",
+							"mountPoints": [
+								{
+									"name": "tempvol",
+									"path": "/foo"
+								}
+							]
+						}
+					}
+				],
+				"volumes": [
+					{
+					"name": "tempvol",
+					"kind": "host",
+					"source": "%s"
+					}
+				]
+			}`, string(exp), file, tmpvol),
+			"net": []string{"none"},
+		},
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+		Resources: &structs.Resources{
+			MemoryMB: 128,
+			CPU:      100,
+		},
+	}
+
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
+	resp, err := d.Start(ctx.ExecCtx, task)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer resp.Handle.Kill()
+
+	select {
+	case res := <-resp.Handle.WaitCh():
+		if !res.Successful() {
+			t.Fatalf("err: %v", res)
+		}
+	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+		t.Fatalf("timeout")
+	}
 	// Check that data was written to the shared alloc directory.
 	act, err := ioutil.ReadFile(hostpath)
 	if err != nil {
@@ -437,7 +878,7 @@ func TestRktTrustPrefix(t *testing.T) {
 	}
 }
 
-func TestRktTaskValidate(t *testing.T) {
+func TestRktTaskValidate_With_Image(t *testing.T) {
 	t.Parallel()
 	ctestutils.RktCompatible(t)
 	task := &structs.Task{
@@ -462,8 +903,180 @@ func TestRktTaskValidate(t *testing.T) {
 	}
 }
 
+func TestRktTaskValidate_With_SingleApp_PodManifest(t *testing.T) {
+	t.Parallel()
+	ctestutils.RktCompatible(t)
+	task := &structs.Task{
+		Name:   "etcd",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"pod_manifest": `{
+				"acVersion": "1.27.0",
+				"acKind": "PodManifest",
+				"apps": [
+					{
+						"name": "coreos",
+						"image": {
+							"name": "coreos.com/etcd",
+							"labels": [
+								{
+									"name":  "version",
+									"value": "v2.0.4"
+								}
+							]
+						},
+						"app": {
+								"exec": ["/etcd","--version"],
+								"user": "0",
+								"group": "0"
+						}
+					}
+				]
+			}`,
+			"dns_servers":        []string{"8.8.8.8", "8.8.4.4"},
+			"dns_search_domains": []string{"example.com", "example.org", "example.net"},
+		},
+		Resources: basicResources,
+	}
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+
+	if err := d.Validate(task.Config); err != nil {
+		t.Fatalf("Validation error in TaskConfig : '%v'", err)
+	}
+
+}
+
+func TestRktTaskValidate_With_MultipleApps_PodManifest(t *testing.T) {
+	t.Parallel()
+	ctestutils.RktCompatible(t)
+	task := &structs.Task{
+		Name:   "etcd_alpine",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"pod_manifest": `{
+				"acVersion": "1.27.0",
+				"acKind": "PodManifest",
+				"apps": [
+					{
+						"name": "coreos",
+						"image": {
+							"name": "coreos.com/etcd",
+							"labels": [
+								{
+									"name":  "version",
+									"value": "v2.0.4"
+								}
+							]
+						},
+						"app": {
+								"exec": ["/etcd","--version"],
+								"user": "0",
+								"group": "0"
+						}
+					},
+					{
+						"name": "alpine",
+						"image": {
+							"name": "docker://alpine"
+						},
+						"app": {
+								"exec": ["/bin/sh"],
+								"user": "0",
+								"group": "0"
+						}
+					}
+				]
+			}`,
+			"dns_servers":        []string{"8.8.8.8", "8.8.4.4"},
+			"dns_search_domains": []string{"example.com", "example.org", "example.net"},
+		},
+		Resources: basicResources,
+	}
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+
+	if err := d.Validate(task.Config); err != nil {
+		t.Fatalf("Validation error in TaskConfig : '%v'", err)
+	}
+
+}
+
+func TestRktTaskValidate_Without_PodManifest_And_Image(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+	ctestutils.RktCompatible(t)
+	task := &structs.Task{
+		Name:   "etcd",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"trust_prefix":       "coreos.com/etcd",
+			"command":            "/etcd",
+			"args":               []string{"--version"},
+			"dns_servers":        []string{"8.8.8.8", "8.8.4.4"},
+			"dns_search_domains": []string{"example.com", "example.org", "example.net"},
+		},
+		Resources: basicResources,
+	}
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+
+	err := d.Validate(task.Config)
+	assert.NotNil(err)
+}
+
+func TestRktTaskValidate_With_PodManifest_And_Image(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+	ctestutils.RktCompatible(t)
+	task := &structs.Task{
+		Name:   "etcd",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"trust_prefix": "coreos.com/etcd",
+			"image":        "coreos.com/etcd:v2.0.4",
+			"pod_manifest": `{
+				"acVersion": "1.27.0",
+				"acKind": "PodManifest",
+				"apps": [
+					{
+						"name": "coreos",
+						"image": {
+							"name": "coreos.com/etcd",
+							"labels": [
+								{
+									"name":  "version",
+									"value": "v2.0.4"
+								}
+							]
+						},
+						"app": {
+								"exec": ["/etcd","--version"],
+								"user": "0",
+								"group": "0"
+						}
+					}
+				]
+			}`,
+			"dns_servers":        []string{"8.8.8.8", "8.8.4.4"},
+			"dns_search_domains": []string{"example.com", "example.org", "example.net"},
+		},
+		Resources: basicResources,
+	}
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+
+	err := d.Validate(task.Config)
+	assert.NotNil(err)
+
+}
+
 // TODO: Port Mapping test should be ran with proper ACI image and test the port access.
-func TestRktDriver_PortsMapping(t *testing.T) {
+func TestRktDriver_PortsMapping_With_Image(t *testing.T) {
 	if !testutil.IsTravis() {
 		t.Parallel()
 	}
@@ -532,9 +1145,249 @@ func TestRktDriver_PortsMapping(t *testing.T) {
 	}
 }
 
-// TestRktDriver_PortsMapping_Host asserts that port_map isn't required when
+func TestRktDriver_PortsMapping_With_SingleApp_PodManifest(t *testing.T) {
+	if !testutil.IsTravis() {
+		t.Parallel()
+	}
+	if os.Getenv("NOMAD_TEST_RKT") == "" {
+		t.Skip("skipping rkt tests")
+	}
+
+	ctestutils.RktCompatible(t)
+	task := &structs.Task{
+		Name:   "redis",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"pod_manifest": `{
+				"acVersion": "1.27.0",
+				"acKind": "PodManifest",
+				"apps": [
+					{
+						"name": "redis",
+						"image": {
+							"name": "docker://redis"
+						},
+						"app": {
+                             "exec": [
+                                "docker-entrypoint.sh",
+                                "redis-server"
+                            ],
+							"user": "0",
+							"group": "0",
+                            "environment": [
+                                {
+                                    "name": "PATH",
+                                    "value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+                                }
+                            ],
+							"ports": [
+								{
+									"name": "6379-tcp",
+									"protocol": "tcp",
+									"port": 6379,
+									"count": 1,
+									"socketActivated": false
+								}
+							]
+						}
+					}
+				]
+			}`,
+			"port_map": []map[string]string{
+				{
+					"main": "6379-tcp",
+				},
+			},
+			"debug": "true",
+		},
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+		Resources: &structs.Resources{
+			MemoryMB: 256,
+			CPU:      512,
+			Networks: []*structs.NetworkResource{
+				{
+					IP:            "127.0.0.1",
+					ReservedPorts: []structs.Port{{Label: "main", Value: 8080}},
+				},
+			},
+		},
+	}
+
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
+	resp, err := d.Start(ctx.ExecCtx, task)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp.Network == nil {
+		t.Fatalf("Expected driver to set a DriverNetwork, but it did not!")
+	}
+
+	failCh := make(chan error, 1)
+	go func() {
+		time.Sleep(1 * time.Second)
+		if err := resp.Handle.Kill(); err != nil {
+			failCh <- err
+		}
+	}()
+
+	select {
+	case err := <-failCh:
+		t.Fatalf("failed to kill handle: %v", err)
+	case <-resp.Handle.WaitCh():
+	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+		t.Fatalf("timeout")
+	}
+}
+
+func TestRktDriver_PortsMapping_With_MultipleApps_PodManifest(t *testing.T) {
+	if !testutil.IsTravis() {
+		t.Parallel()
+	}
+	if os.Getenv("NOMAD_TEST_RKT") == "" {
+		t.Skip("skipping rkt tests")
+	}
+
+	ctestutils.RktCompatible(t)
+	task := &structs.Task{
+		Name:   "redis_nginx",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"pod_manifest": `{
+				"acVersion": "1.27.0",
+				"acKind": "PodManifest",
+				"apps": [
+					{
+						"name": "redis",
+						"image": {
+							"name": "docker://redis"
+						},
+						"app": {
+                             "exec": [
+                                "docker-entrypoint.sh",
+                                "redis-server"
+                            ],
+							"user": "0",
+							"group": "0",
+                            "environment": [
+                                {
+                                    "name": "PATH",
+                                    "value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+                                }
+                            ],
+							"ports": [
+								{
+									"name": "6379-tcp",
+									"protocol": "tcp",
+									"port": 6379,
+									"count": 1,
+									"socketActivated": false
+								}
+							]
+						}
+					},
+					{
+						"name": "nginx",
+						"image": {
+							"name": "docker://nginx"
+						},
+						"app": {
+							"exec": [
+								"nginx",
+								"-g",
+								"daemon off;"
+							],
+							"user": "0",
+							"group": "0",
+							"environment": [
+								{
+									"name": "PATH",
+									"value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+								}
+							],
+							"ports": [
+								{
+									"name": "80-tcp",
+									"protocol": "tcp",
+									"port": 80,
+									"count": 1,
+									"socketActivated": false
+								}
+							]
+						}
+					}
+				]
+			}`,
+			"port_map": []map[string]string{
+				{
+					"db":     "6379-tcp",
+					"server": "80-tcp",
+				},
+			},
+			"debug": "true",
+		},
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+		Resources: &structs.Resources{
+			MemoryMB: 256,
+			CPU:      512,
+			Networks: []*structs.NetworkResource{
+				{
+					IP: "127.0.0.1",
+					ReservedPorts: []structs.Port{
+						{Label: "db", Value: 8080},
+						{Label: "server", Value: 8081},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
+	resp, err := d.Start(ctx.ExecCtx, task)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp.Network == nil {
+		t.Fatalf("Expected driver to set a DriverNetwork, but it did not!")
+	}
+
+	failCh := make(chan error, 1)
+	go func() {
+		time.Sleep(1 * time.Second)
+		if err := resp.Handle.Kill(); err != nil {
+			failCh <- err
+		}
+	}()
+
+	select {
+	case err := <-failCh:
+		t.Fatalf("failed to kill handle: %v", err)
+	case <-resp.Handle.WaitCh():
+	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+		t.Fatalf("timeout")
+	}
+}
+
+// TestRktDriver_PortsMapping_Host_With_Image asserts that port_map isn't required when
 // host networking is used.
-func TestRktDriver_PortsMapping_Host(t *testing.T) {
+func TestRktDriver_PortsMapping_Host_With_Image(t *testing.T) {
 	if !testutil.IsTravis() {
 		t.Parallel()
 	}
@@ -598,7 +1451,167 @@ func TestRktDriver_PortsMapping_Host(t *testing.T) {
 	}
 }
 
-func TestRktDriver_HandlerExec(t *testing.T) {
+// TestRktDriver_PortsMapping_Host_With_SingleApp_PodManifest asserts that port_map isn't required
+// when host networking is used.
+func TestRktDriver_PortsMapping_Host_With_SingleApp_PodManifest(t *testing.T) {
+	if !testutil.IsTravis() {
+		t.Parallel()
+	}
+	if os.Getenv("NOMAD_TEST_RKT") == "" {
+		t.Skip("skipping rkt tests")
+	}
+
+	ctestutils.RktCompatible(t)
+	task := &structs.Task{
+		Name:   "redis",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"pod_manifest": `{
+				"acVersion": "1.27.0",
+				"acKind": "PodManifest",
+				"apps": [
+					{
+						"name": "redis",
+						"image": {
+							"name": "docker://redis"
+						}
+					}
+				]
+			}`,
+			"net": []string{"host"},
+		},
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+		Resources: &structs.Resources{
+			MemoryMB: 256,
+			CPU:      512,
+			Networks: []*structs.NetworkResource{
+				{
+					IP:            "127.0.0.1",
+					ReservedPorts: []structs.Port{{Label: "main", Value: 8080}},
+				},
+			},
+		},
+	}
+
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
+	resp, err := d.Start(ctx.ExecCtx, task)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp.Network != nil {
+		t.Fatalf("No network should be returned with --net=host but found: %#v", resp.Network)
+	}
+
+	failCh := make(chan error, 1)
+	go func() {
+		time.Sleep(1 * time.Second)
+		if err := resp.Handle.Kill(); err != nil {
+			failCh <- err
+		}
+	}()
+
+	select {
+	case err := <-failCh:
+		t.Fatalf("failed to kill handle: %v", err)
+	case <-resp.Handle.WaitCh():
+	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+		t.Fatalf("timeout")
+	}
+}
+
+// TestRktDriver_PortsMapping_Host_With_MultipleApps_PodManifest asserts that port_map isn't required
+// when host networking is used.
+func TestRktDriver_PortsMapping_Host_With_MultipleApps_PodManifest(t *testing.T) {
+	if !testutil.IsTravis() {
+		t.Parallel()
+	}
+	if os.Getenv("NOMAD_TEST_RKT") == "" {
+		t.Skip("skipping rkt tests")
+	}
+
+	ctestutils.RktCompatible(t)
+	task := &structs.Task{
+		Name:   "redis_alpine",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"pod_manifest": `{
+				"acVersion": "1.27.0",
+				"acKind": "PodManifest",
+				"apps": [
+					{
+						"name": "redis",
+						"image": {
+							"name": "docker://redis"
+						}
+					},
+					{
+						"name": "alpine",
+						"image": {
+							"name": "docker://alpine"
+						}
+					}
+				]
+			}`,
+			"net": []string{"host"},
+		},
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+		Resources: &structs.Resources{
+			MemoryMB: 256,
+			CPU:      512,
+			Networks: []*structs.NetworkResource{
+				{
+					IP:            "127.0.0.1",
+					ReservedPorts: []structs.Port{{Label: "main", Value: 8080}},
+				},
+			},
+		},
+	}
+
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
+	resp, err := d.Start(ctx.ExecCtx, task)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp.Network != nil {
+		t.Fatalf("No network should be returned with --net=host but found: %#v", resp.Network)
+	}
+
+	failCh := make(chan error, 1)
+	go func() {
+		time.Sleep(1 * time.Second)
+		if err := resp.Handle.Kill(); err != nil {
+			failCh <- err
+		}
+	}()
+
+	select {
+	case err := <-failCh:
+		t.Fatalf("failed to kill handle: %v", err)
+	case <-resp.Handle.WaitCh():
+	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+		t.Fatalf("timeout")
+	}
+}
+
+func TestRktDriver_HandlerExec_With_Image(t *testing.T) {
 	if !testutil.IsTravis() {
 		t.Parallel()
 	}
@@ -669,6 +1682,201 @@ func TestRktDriver_HandlerExec(t *testing.T) {
 	}
 }
 
+func TestRktDriver_HandlerExec_With_SingleApp_PodManifest(t *testing.T) {
+	if !testutil.IsTravis() {
+		t.Parallel()
+	}
+	if os.Getenv("NOMAD_TEST_RKT") == "" {
+		t.Skip("skipping rkt tests")
+	}
+
+	ctestutils.RktCompatible(t)
+	task := &structs.Task{
+		Name:   "etcd",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"pod_manifest": `{
+				"acVersion": "1.27.0",
+				"acKind": "PodManifest",
+				"apps": [
+					{
+						"name": "coreos",
+						"image": {
+							"name": "coreos.com/etcd",
+							"labels": [
+								{
+									"name":  "version",
+									"value": "v2.0.4"
+								}
+							]
+						},
+						"app": {
+								"exec": ["/etcd"],
+								"user": "0",
+								"group": "0"
+						}
+					}
+				]
+			}`,
+		},
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+		Resources: &structs.Resources{
+			MemoryMB: 128,
+			CPU:      100,
+		},
+	}
+
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
+	resp, err := d.Start(ctx.ExecCtx, task)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Give the pod a second to start
+	time.Sleep(time.Second)
+
+	// Exec a command that should work
+	out, code, err := resp.Handle.Exec(context.TODO(), "/etcd", []string{"--version"})
+	if err != nil {
+		t.Fatalf("error exec'ing etcd --version: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("expected `etcd --version` to succeed but exit code was: %d\n%s", code, string(out))
+	}
+	if expected := []byte("etcd version "); !bytes.HasPrefix(out, expected) {
+		t.Fatalf("expected output to start with %q but found:\n%q", expected, out)
+	}
+
+	// Exec a command that should fail
+	out, code, err = resp.Handle.Exec(context.TODO(), "/etcd", []string{"--kaljdshf"})
+	if err != nil {
+		t.Fatalf("error exec'ing bad command: %v", err)
+	}
+	if code == 0 {
+		t.Fatalf("expected `stat` to fail but exit code was: %d", code)
+	}
+	if expected := "flag provided but not defined"; !bytes.Contains(out, []byte(expected)) {
+		t.Fatalf("expected output to contain %q but found: %q", expected, out)
+	}
+
+	if err := resp.Handle.Kill(); err != nil {
+		t.Fatalf("error killing handle: %v", err)
+	}
+}
+
+// This, tests with just the first app in the pod manifest as the code
+// currently picks up the first app by default when there are multiple apps in a pod manifest
+func TestRktDriver_HandlerExec_With_MultipleApps_PodManifest(t *testing.T) {
+	if !testutil.IsTravis() {
+		t.Parallel()
+	}
+	if os.Getenv("NOMAD_TEST_RKT") == "" {
+		t.Skip("skipping rkt tests")
+	}
+
+	ctestutils.RktCompatible(t)
+	task := &structs.Task{
+		Name:   "etcd_alpine",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"pod_manifest": `{
+				"acVersion": "1.27.0",
+				"acKind": "PodManifest",
+				"apps": [
+					{
+						"name": "coreos",
+						"image": {
+							"name": "coreos.com/etcd",
+							"labels": [
+								{
+									"name":  "version",
+									"value": "v2.0.4"
+								}
+							]
+						},
+						"app": {
+								"exec": ["/etcd"],
+								"user": "0",
+								"group": "0"
+						}
+					},
+					{
+						"name": "alpine",
+						"image": {
+							"name": "docker://alpine"
+						},
+						"app": {
+								"exec": ["/bin/sh"],
+								"user": "0",
+								"group": "0"
+						}
+					}
+				]
+			}`,
+		},
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+		Resources: &structs.Resources{
+			MemoryMB: 128,
+			CPU:      100,
+		},
+	}
+
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
+	resp, err := d.Start(ctx.ExecCtx, task)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Give the pod a second to start
+	time.Sleep(time.Second)
+
+	// Exec a command on coreos app that should work
+	out, code, err := resp.Handle.Exec(context.TODO(), "/etcd", []string{"--version"})
+	if err != nil {
+		t.Fatalf("error exec'ing etcd --version: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("expected `etcd --version` to succeed but exit code was: %d\n%s", code, string(out))
+	}
+	if expected := []byte("etcd version "); !bytes.HasPrefix(out, expected) {
+		t.Fatalf("expected output to start with %q but found:\n%q", expected, out)
+	}
+
+	// Exec a command on coreos app that should fail
+	out, code, err = resp.Handle.Exec(context.TODO(), "/etcd", []string{"--kaljdshf"})
+	if err != nil {
+		t.Fatalf("error exec'ing bad command: %v", err)
+	}
+	if code == 0 {
+		t.Fatalf("expected `stat` to fail but exit code was: %d", code)
+	}
+	if expected := "flag provided but not defined"; !bytes.Contains(out, []byte(expected)) {
+		t.Fatalf("expected output to contain %q but found: %q", expected, out)
+	}
+
+	if err := resp.Handle.Kill(); err != nil {
+		t.Fatalf("error killing handle: %v", err)
+	}
+}
+
 func TestRktDriver_Remove_Error(t *testing.T) {
 	if !testutil.IsTravis() {
 		t.Parallel()
@@ -687,4 +1895,60 @@ func TestRktDriver_Remove_Error(t *testing.T) {
 	if err := rktRemove("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"); err == nil {
 		t.Fatalf("expected an error")
 	}
+}
+
+// This test ensures that pod manifest can be used without errors when the optional fields are absent.
+func TestRktDriver_PodManifest_Optional_Fields_Start(t *testing.T) {
+	if !testutil.IsTravis() {
+		t.Parallel()
+	}
+	if os.Getenv("NOMAD_TEST_RKT") == "" {
+		t.Skip("skipping rkt tests")
+	}
+
+	ctestutils.RktCompatible(t)
+	task := &structs.Task{
+		Name:   "etcd",
+		Driver: "rkt",
+		Config: map[string]interface{}{
+			"trust_prefix": "coreos.com/etcd",
+			"pod_manifest": `{
+				"acVersion": "1.27.0",
+				"acKind": "PodManifest",
+				"apps": [
+					{
+						"name": "coreos",
+						"image": {
+							"name": "coreos.com/etcd",
+							"labels": [
+								{
+									"name":  "version",
+									"value": "v2.0.4"
+								}
+							]
+						}
+					}
+				]
+			}`,
+		},
+		LogConfig: &structs.LogConfig{
+			MaxFiles:      10,
+			MaxFileSizeMB: 10,
+		},
+		Resources: &structs.Resources{
+			MemoryMB: 128,
+			CPU:      100,
+		},
+	}
+	ctx := testDriverContexts(t, task)
+	defer ctx.AllocDir.Destroy()
+	d := NewRktDriver(ctx.DriverCtx)
+	if _, err := d.Prestart(ctx.ExecCtx, task); err != nil {
+		t.Fatalf("error in prestart: %v", err)
+	}
+	resp, err := d.Start(ctx.ExecCtx, task)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	resp.Handle.Kill()
 }

--- a/vendor/github.com/appc/spec/schema/lastditch/doc.go
+++ b/vendor/github.com/appc/spec/schema/lastditch/doc.go
@@ -1,0 +1,28 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package lastditch provides fallback redefinitions of parts of
+// schemas provided by schema package.
+//
+// Almost no validation of schemas is done (besides checking if data
+// really is `JSON`-encoded and kind is either `ImageManifest` or
+// `PodManifest`. This is to get as much data as possible from an
+// invalid manifest. The main aim of the package is to be used for the
+// better error reporting. The another aim might be to force some
+// operation (like removing a pod), which would otherwise fail because
+// of an invalid manifest.
+//
+// To avoid validation during deserialization, types provided by this
+// package use plain strings.
+package lastditch

--- a/vendor/github.com/appc/spec/schema/lastditch/image.go
+++ b/vendor/github.com/appc/spec/schema/lastditch/image.go
@@ -1,0 +1,45 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lastditch
+
+import (
+	"encoding/json"
+
+	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
+)
+
+type ImageManifest struct {
+	ACVersion string `json:"acVersion"`
+	ACKind    string `json:"acKind"`
+	Name      string `json:"name"`
+	Labels    Labels `json:"labels,omitempty"`
+}
+
+// a type just to avoid a recursion during unmarshalling
+type imageManifest ImageManifest
+
+func (im *ImageManifest) UnmarshalJSON(data []byte) error {
+	i := imageManifest(*im)
+	err := json.Unmarshal(data, &i)
+	if err != nil {
+		return err
+	}
+	if i.ACKind != string(schema.ImageManifestKind) {
+		return types.InvalidACKindError(schema.ImageManifestKind)
+	}
+	*im = ImageManifest(i)
+	return nil
+}

--- a/vendor/github.com/appc/spec/schema/lastditch/labels.go
+++ b/vendor/github.com/appc/spec/schema/lastditch/labels.go
@@ -12,28 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package schema
+package lastditch
 
 import (
-	"github.com/appc/spec/schema/types"
+	"encoding/json"
 )
 
-const (
-	// version represents the canonical version of the appc spec and tooling.
-	// For now, the schema and tooling is coupled with the spec itself, so
-	// this must be kept in sync with the VERSION file in the root of the repo.
-	version string = "0.8.11+git"
-)
+type Labels []Label
 
-var (
-	// AppContainerVersion is the SemVer representation of version
-	AppContainerVersion types.SemVer
-)
+// a type just to avoid a recursion during unmarshalling
+type labels Labels
 
-func init() {
-	v, err := types.NewSemVer(version)
-	if err != nil {
-		panic(err)
+type Label struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+func (l *Labels) UnmarshalJSON(data []byte) error {
+	var jl labels
+	if err := json.Unmarshal(data, &jl); err != nil {
+		return err
 	}
-	AppContainerVersion = *v
+	*l = Labels(jl)
+	return nil
 }

--- a/vendor/github.com/appc/spec/schema/lastditch/pod.go
+++ b/vendor/github.com/appc/spec/schema/lastditch/pod.go
@@ -1,0 +1,57 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lastditch
+
+import (
+	"encoding/json"
+
+	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
+)
+
+type PodManifest struct {
+	ACVersion string  `json:"acVersion"`
+	ACKind    string  `json:"acKind"`
+	Apps      AppList `json:"apps"`
+}
+
+type AppList []RuntimeApp
+
+type RuntimeApp struct {
+	Name  string       `json:"name"`
+	Image RuntimeImage `json:"image"`
+}
+
+type RuntimeImage struct {
+	Name   string `json:"name,omitempty"`
+	ID     string `json:"id"`
+	Labels Labels `json:"labels,omitempty"`
+}
+
+// a type just to avoid a recursion during unmarshalling
+type podManifest PodManifest
+
+func (pm *PodManifest) UnmarshalJSON(data []byte) error {
+	p := podManifest(*pm)
+	err := json.Unmarshal(data, &p)
+	if err != nil {
+		return err
+	}
+	if p.ACKind != string(schema.PodManifestKind) {
+		return types.InvalidACKindError(schema.PodManifestKind)
+	}
+	*pm = PodManifest(p)
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,7 @@
 	"ignore": "test appengine",
 	"package": [
 		{"path":"context","revision":""},
+		{"path":"githbu.com/appc/spec","revision":""},
 		{"path":"github.com/Azure/go-ansiterm","checksumSHA1":"23FJUX+AInYeEM2hoUMvYZtXZd4=","revision":"fa152c58bc15761d0200cb75fe958b89a9d4888e","revisionTime":"2016-06-22T17:32:16Z"},
 		{"path":"github.com/Azure/go-ansiterm/winterm","checksumSHA1":"jBimnggjIiFUjaImNoJhSVLtdzw=","revision":"fa152c58bc15761d0200cb75fe958b89a9d4888e","revisionTime":"2016-06-22T17:32:16Z"},
 		{"path":"github.com/DataDog/datadog-go/statsd","checksumSHA1":"WvApwvvSe3i/3KO8300dyeFmkbI=","revision":"b10af4b12965a1ad08d164f57d14195b4140d8de","revisionTime":"2017-08-09T10:47:06Z"},
@@ -12,8 +13,9 @@
 		{"path":"github.com/RackSec/srslog","checksumSHA1":"OTN4c1F0p+mEG2CpkU1Kuavupf0=","revision":"259aed10dfa74ea2961eddd1d9847619f6e98837","revisionTime":"2016-01-20T22:33:50Z"},
 		{"path":"github.com/Sirupsen/logrus","comment":"v0.8.7-87-g4b6ea73","revision":"4b6ea7319e214d98c938f12692336f7ca9348d6b"},
 		{"path":"github.com/StackExchange/wmi","checksumSHA1":"qtjd74+bErubh+qyv3s+lWmn9wc=","revision":"ea383cf3ba6ec950874b8486cd72356d007c768f","revisionTime":"2017-04-10T19:29:09Z"},
-		{"path":"github.com/appc/spec/schema","checksumSHA1":"uWJDTv0R/NJVYv51LVy6vKP1CZw=","revision":"cbe99b7160b1397bf89f9c8bb1418f69c9424049","revisionTime":"2017-09-19T09:55:19Z"},
+		{"path":"github.com/appc/spec/schema","checksumSHA1":"bqIsFbIkjjS17KU1/sbNXCtLKS8=","revision":"259c2eebc32df77c016974d5e8eed390d5a81500","revisionTime":"2018-01-24T15:52:24Z"},
 		{"path":"github.com/appc/spec/schema/common","checksumSHA1":"Q47G6996hbfQaNp/8CFkGWTVQpw=","revision":"cbe99b7160b1397bf89f9c8bb1418f69c9424049","revisionTime":"2017-09-19T09:55:19Z"},
+		{"path":"github.com/appc/spec/schema/lastditch","checksumSHA1":"pAFdOs1eM1NPuDvK4liRRUwE86A=","revision":"259c2eebc32df77c016974d5e8eed390d5a81500","revisionTime":"2018-01-24T15:52:24Z"},
 		{"path":"github.com/appc/spec/schema/types","checksumSHA1":"kYXCle7Ikc8WqiMs7NXz99bUWqo=","revision":"cbe99b7160b1397bf89f9c8bb1418f69c9424049","revisionTime":"2017-09-19T09:55:19Z"},
 		{"path":"github.com/appc/spec/schema/types/resource","checksumSHA1":"VgPsPj5PH7LKXMa3ZLe5/+Avydo=","revision":"cbe99b7160b1397bf89f9c8bb1418f69c9424049","revisionTime":"2017-09-19T09:55:19Z"},
 		{"path":"github.com/armon/circbuf","revision":"bbbad097214e2918d8543d5201d12bfd7bca254d"},


### PR DESCRIPTION
The job spec for the rkt driver now supports an additional key:
`pod_manifest`; This makes `image` and `pod_manifest` exclusive of each
other. Currently the pod_manifest supplied as user input can be
accepted if it does not have an image id. rkt fetches the image using
the image name and modifies the pod manifest with the obtained image
id before passing it along to `rkt prepare`. 

As a result, now multiple rkt containers can run within the same nomad 
task.

**Testing:**
- Setup nomad locally.
- `sudo consul agent -dev` 
- `make dev && sudo bin/nomad agent -dev`.
- Get [example.nomad](https://gist.github.com/indradhanush/f0747d8acc42e353eeeb36c05d76e457).
- `bin/nomad run example.nomad`.
- To test a pod with multiple containers get: [dual.nomad](https://gist.github.com/indradhanush/57d86273d499522ad29e87f497b7922e) and run `bin/nomad run dual.nomad`.

**Expected output:**
- `bin/nomad status example` should give you a status of `running` after a few minutes.
- `bin/nomad alloc-status <alloc-id>` should give the status of redis.
- `bin/nomad status dual` should return the `alloc-id`. Use it to get the `alloc-status`. This should tell you the ports on which `nginx` and `redis` are running. The port named `server` runs nginx and you can test it with `curl http://127.0.0.1:<port>`. This should return the default nginx page.
- Get the [redis cli](https://redis.io/clients) and run it with `redis-cli -p <port>` and play around. :)
